### PR TITLE
Remove check to open data communication to same IP

### DIFF
--- a/lib/DefaultAuthHandler.cs
+++ b/lib/DefaultAuthHandler.cs
@@ -37,8 +37,7 @@ namespace mooftpserv
 
         public bool AllowActiveDataConnection(IPEndPoint port)
         {
-            // only allow active connections to the same peer as the control connection
-            return peer.Address.Equals(port.Address);
+            return true;
         }
     }
 }


### PR DESCRIPTION
According to https://www.w3.org/Protocols/rfc959/8_PortNumber.html it is perfectly legal to let data communication go from/to different IP address. It is even possible that client instructs two servers to send data to each other. So the check I just removed violated RFC

From RFC:
In another situation a user might wish to transfer files between
two hosts, neither of which is a local host. The user sets up
control connections to the two servers and then arranges for a
data connection between them. 