### PR TITLE
Memory leak fix

### DIFF
--- a/lib/Session.cs
+++ b/lib/Session.cs
@@ -109,8 +109,8 @@ namespace mooftpserv
         public void Start()
         {
             if (!threadAlive) {
-                this.thread.Start();
                 threadAlive = true;
+                this.thread.Start();
             }
         }
 


### PR DESCRIPTION
When a connection to the server is created an immediately closed the session may not be ever released. This is caused by a race condition when the thread is executed faster than 'threadAlive' is set. 'Work' method is executed first and sets 'threadAlive' to 'false' and than 'Start' continues and sets 'threadAlive' to 'true'.